### PR TITLE
Show Intu dashboard on Pepper's tablet 

### DIFF
--- a/platform/nao/services/NaoBrowser.cpp
+++ b/platform/nao/services/NaoBrowser.cpp
@@ -24,6 +24,7 @@
 
 #include "SelfInstance.h"
 #include "NaoPlatform.h"
+#include "utils/URL.h"
 
 REG_SERIALIZABLE(NaoBrowser);
 RTTI_IMPL( NaoBrowser, IBrowser);
@@ -40,7 +41,7 @@ NaoBrowser::NaoBrowser() : IBrowser("URLServiceV1"),
 	m_LastUpdate( 0 ),
 	m_LastCheck( 0 ),
 	m_TabletCheckInterval(10.0), 
-	m_TabletDisplayTime(120.0), 
+	m_TabletDisplayTime(0.0), 
 	m_fBrightness(1.0)
 {}
 
@@ -129,7 +130,7 @@ void NaoBrowser::TabletThread()
 			}
 			m_RequestListLock.unlock();
 
-			if ( !m_bLogoDisplayed && ((now - m_LastUpdate) > m_TabletDisplayTime) )
+			if ( !m_bLogoDisplayed && ((now - m_LastUpdate) > m_TabletDisplayTime) && m_TabletDisplayTime > 0 )
 				DisplayLogo();
 		}
 

--- a/platform/nao/services/NaoBrowser.cpp
+++ b/platform/nao/services/NaoBrowser.cpp
@@ -141,7 +141,11 @@ void NaoBrowser::TabletThread()
 
 void NaoBrowser::TabletShowURL( const Url::SP & a_spUrl, UrlCallback a_Callback )
 {
-	std::string url( IBrowser::EscapeUrl( a_spUrl->GetURL()) );
+	// Map "localhost" to the IP address of the robot relative to the tablet
+	URL mappedURL = URL(a_spUrl->GetURL());
+	if (_stricmp(mappedURL.GetHost().c_str(), "localhost") == 0)
+		mappedURL.SetHost("198.18.0.1");
+	std::string url( IBrowser::EscapeUrl( mappedURL.GetURL()).c_str() );
 	try {
 		Log::Status( "NaoBrowser", "Showing URL: %s", url.c_str() );
 		m_LastUpdate = Time().GetEpochTime();


### PR DESCRIPTION
Since Pepper's panel is an Android tablet running a web browser on it, and has different IP address from the Pepper's one, accessing http://localhost:9443/www/dashboard#/ on the tablet can't reach the dashboard server of the Intu process on the Pepper. This patch simply maps "localhost" in the URL into "198.18.0.1" which is Pepper's end-point address of the point-to-point network on USB connection between Pepper and Android tablet.
Please note that this patch enables only showing of dashboard on the Pepper. To configure Intu through dashboard, you would need to access the dashboard from remote web browser running on PC/Mac. 

Signed-off-by: Takao Moriyama moriyama@jp.ibm.com