### PR TITLE
Avoid crashing on Pepper when 2nd dashboard instance is created

### DIFF
--- a/platform/nao/sensors/NaoSpeechToText.cpp
+++ b/platform/nao/sensors/NaoSpeechToText.cpp
@@ -35,7 +35,7 @@ bool NaoSpeechToText::OnStart()
     Log::Status("NaoSpeechToText", "NaoSpeechToText started");
     m_Paused = 0;
 
-    ThreadPool::Instance()->InvokeOnThread<void *>(DELEGATE(NaoSpeechToText, ReceiveData, void *, this), NULL);
+    ReceiveData(this);
     return true;
 }
 


### PR DESCRIPTION
This is a solution for the issue https://github.com/watson-intu/self/issues/31.

There was a time-critical condition when NaoSpeechToText::OnStart() and NaoSpeechToText::OnStop() are executed in a row, which might cause Intu crash in NaSpeechToText. The real cause is that the deactivation process of ALSpeechRecognitionProxy is started before activation of it is still in process in a separated thread.

This solution is just run the activation process in the main thread, which may block main thread for 80mSec to 200mSec depending on the condition.

Signed-off-by: Takao Moriyama moriyama@jp.ibm.com